### PR TITLE
empty props implementation for not formatting empty values

### DIFF
--- a/spec/vue_numeric.spec.js
+++ b/spec/vue_numeric.spec.js
@@ -143,4 +143,25 @@ describe('vue-numeric', () => {
       done()
     })
   })
+
+  it('don\'t format empty values', done => {
+    const vm = new Vue({
+      el,
+      data () {
+        return {
+          total: ""
+        }
+      },
+      template: '<div><vue-numeric :empty="true" v-model="total"></vue-numeric></div>',
+      components: { VueNumeric }
+    }).$mount()
+
+    Vue.nextTick(() => {
+      setTimeout(() => {
+        expect(vm.$el.firstChild.value).toEqual("")
+        done()
+      }, 600)
+    })
+  })
+
 })

--- a/src/vue-numeric.vue
+++ b/src/vue-numeric.vue
@@ -246,6 +246,7 @@ export default {
         })
       else
         this.amount=this.value;
+
     },
 
     /**
@@ -253,7 +254,7 @@ export default {
      * @param {Number} value
      */
     updateValue (value) {
-      this.$emit('input', value ? Number(accounting.toFixed(value, this.precision)) : null)
+      this.$emit('input', this.checkEmptyValue(this.amount) ? Number(accounting.toFixed(value, this.precision)) : null)
     },
 
     /**

--- a/src/vue-numeric.vue
+++ b/src/vue-numeric.vue
@@ -191,7 +191,7 @@ export default {
      */
     checkEmptyValue (value) {
       if (this.empty && (value == "" || value == null))
-        return false
+        return (parseInt(value)==0)
       return true
     },
 
@@ -237,7 +237,7 @@ export default {
      * Format value using symbol and separator.
      */
     formatValue () {
-      if (this.checkEmptyValue(this.value))
+      if (this.checkEmptyValue(this.amount))
         this.amount = accounting.formatMoney(this.numberValue, {
           symbol: this.currency + ' ',
           precision: Number(this.precision),
@@ -274,8 +274,9 @@ export default {
      * @param {Number} value
      */
     convertToNumber (value) {
-      if (this.checkEmptyValue(value))
+      if (this.checkEmptyValue(this.value)) {
         this.amount = this.numberToString(value)
+      }
     }
   },
 

--- a/src/vue-numeric.vue
+++ b/src/vue-numeric.vue
@@ -86,6 +86,15 @@ export default {
     value: {
       required: true,
       type: [Number, String]
+    },
+
+    /**
+     * Empty value allowed.
+     */
+    empty: {
+      default: false,
+      required: false,
+      type: Boolean
     }
   },
 
@@ -175,6 +184,17 @@ export default {
     },
 
     /**
+     * Check provided value againts allowed.
+     * @param {Number} value
+     * @return {Boolean}
+     */
+    checkEmptyValue (value) {
+      if (this.empty && (value == "" || value == null))
+        return false
+      return true
+    },
+
+    /**
      * Format provided value to number type.
      * @param {String} value
      * @return {Number}
@@ -201,14 +221,16 @@ export default {
      * @param {Number} value
      */
     processValue (value) {
-      if (isNaN(value)) {
-        this.updateValue(this.minValue)
-      } else if (this.checkMaxValue(value)) {
-        this.updateValue(this.maxValue)
-      } else if (this.checkMinValue(value)) {
-        this.updateValue(this.minValue)
-      } else {
-        this.updateValue(value)
+      if (this.checkEmptyValue(value)) {
+        if (isNaN(value)) {
+          this.updateValue(this.minValue)
+        } else if (this.checkMaxValue(value)) {
+          this.updateValue(this.maxValue)
+        } else if (this.checkMinValue(value)) {
+          this.updateValue(this.minValue)
+        } else {
+          this.updateValue(value)
+        }
       }
     },
 
@@ -216,12 +238,13 @@ export default {
      * Format value using symbol and separator.
      */
     formatValue () {
-      this.amount = accounting.formatMoney(this.numberValue, {
-        symbol: this.currency + ' ',
-        precision: Number(this.precision),
-        decimal: this.decimalSeparator,
-        thousand: this.thousandSeparator
-      })
+      if (!this.empty)
+        this.amount = accounting.formatMoney(this.numberValue, {
+          symbol: this.currency + ' ',
+          precision: Number(this.precision),
+          decimal: this.decimalSeparator,
+          thousand: this.thousandSeparator
+        })      
     },
 
     /**

--- a/src/vue-numeric.vue
+++ b/src/vue-numeric.vue
@@ -237,13 +237,15 @@ export default {
      * Format value using symbol and separator.
      */
     formatValue () {
-      if (this.checkEmptyValue(this.amount))
+      if (this.checkEmptyValue(this.value))
         this.amount = accounting.formatMoney(this.numberValue, {
           symbol: this.currency + ' ',
           precision: Number(this.precision),
           decimal: this.decimalSeparator,
           thousand: this.thousandSeparator
         })
+      else
+        this.amount=this.value;
     },
 
     /**
@@ -272,7 +274,7 @@ export default {
      * @param {Number} value
      */
     convertToNumber (value) {
-      if (this.checkEmptyValue(this.amount))
+      if (this.checkEmptyValue(value))
         this.amount = this.numberToString(value)
     }
   },

--- a/src/vue-numeric.vue
+++ b/src/vue-numeric.vue
@@ -84,8 +84,9 @@ export default {
      * v-model value.
      */
     value: {
-      required: true,
-      type: [Number, String]
+      required: false,
+      type: [Number, String],
+      default: ""
     },
 
     /**
@@ -221,16 +222,14 @@ export default {
      * @param {Number} value
      */
     processValue (value) {
-      if (this.checkEmptyValue(value)) {
-        if (isNaN(value)) {
-          this.updateValue(this.minValue)
-        } else if (this.checkMaxValue(value)) {
-          this.updateValue(this.maxValue)
-        } else if (this.checkMinValue(value)) {
-          this.updateValue(this.minValue)
-        } else {
-          this.updateValue(value)
-        }
+      if (isNaN(value)) {
+        this.updateValue(this.minValue)
+      } else if (this.checkMaxValue(value)) {
+        this.updateValue(this.maxValue)
+      } else if (this.checkMinValue(value)) {
+        this.updateValue(this.minValue)
+      } else {
+        this.updateValue(value)
       }
     },
 
@@ -238,13 +237,13 @@ export default {
      * Format value using symbol and separator.
      */
     formatValue () {
-      if (!this.empty)
+      if (this.checkEmptyValue(this.amount))
         this.amount = accounting.formatMoney(this.numberValue, {
           symbol: this.currency + ' ',
           precision: Number(this.precision),
           decimal: this.decimalSeparator,
           thousand: this.thousandSeparator
-        })      
+        })
     },
 
     /**
@@ -252,7 +251,7 @@ export default {
      * @param {Number} value
      */
     updateValue (value) {
-      this.$emit('input', Number(accounting.toFixed(value, this.precision)))
+      this.$emit('input', value ? Number(accounting.toFixed(value, this.precision)) : null)
     },
 
     /**
@@ -273,7 +272,8 @@ export default {
      * @param {Number} value
      */
     convertToNumber (value) {
-      this.amount = this.numberToString(value)
+      if (this.checkEmptyValue(this.amount))
+        this.amount = this.numberToString(value)
     }
   },
 
@@ -302,8 +302,10 @@ export default {
 
     // In case of delayed v-model new value.
     setTimeout(() => {
-      this.processValue(this.formatToNumber(this.value))
-      this.formatValue(this.value)
+      if (this.checkEmptyValue(this.value)) {
+        this.processValue(this.formatToNumber(this.value))
+        this.formatValue(this.value)
+      }
     }, 500)
   }
 }


### PR DESCRIPTION
Hi @kevinongko!

I did the implementation below, what do you think?

When the value is empty or null, don't format the field so that the placeholder can be displayed, using empty props.

`<vue-numeric :empty="true" v-model="price"></vue-numeric>`