### PR TITLE
Remove space between currency and number

### DIFF
--- a/src/vue-numeric.vue
+++ b/src/vue-numeric.vue
@@ -181,7 +181,7 @@ export default {
      * @return {String} format
      */
     formatString () {
-      return this.currencySymbolPosition === 'suffix' ? '%v %s' : '%s %v'
+      return this.currencySymbolPosition === 'suffix' ? '%v%s' : '%s%v'
     }
   },
 


### PR DESCRIPTION
This was causing me some issues with a span tag and it breaking onto two lines. Perhaps this can be fixed with CSS, but I'm not sure.

Edit: Actually now that I've seen the travis checks, I can see the benefit to the space. Perhaps this would be better with a prop to remove it?