### PR TITLE
Add a watcher for seperator prop

### DIFF
--- a/src/vue-numeric.vue
+++ b/src/vue-numeric.vue
@@ -263,8 +263,13 @@ export default {
         })
       }
     },
-    
-    separator(newValue, oldValue) {
+
+    /**
+     * Immediately reflect separator changes
+     * @param {String} newValue
+     * @param {String} oldValue
+     */
+    separator (newValue, oldValue) {
         if (newValue !== oldValue) {
             this.process(this.valueNumber)
             this.amount = this.format(this.valueNumber)

--- a/src/vue-numeric.vue
+++ b/src/vue-numeric.vue
@@ -266,14 +266,10 @@ export default {
 
     /**
      * Immediately reflect separator changes
-     * @param {String} newValue
-     * @param {String} oldValue
      */
-    separator (newValue, oldValue) {
-        if (newValue !== oldValue) {
-            this.process(this.valueNumber)
-            this.amount = this.format(this.valueNumber)
-        }
+    separator () {
+      this.process(this.valueNumber)
+      this.amount = this.format(this.valueNumber)
     }
   },
 

--- a/src/vue-numeric.vue
+++ b/src/vue-numeric.vue
@@ -262,6 +262,13 @@ export default {
           this.$refs.readOnly.className = this.readOnlyClass
         })
       }
+    },
+    
+    separator(newValue, oldValue) {
+        if (newValue !== oldValue) {
+            this.process(this.valueNumber)
+            this.amount = this.format(this.valueNumber)
+        }
     }
   },
 

--- a/test/specs/vue-numeric.spec.js
+++ b/test/specs/vue-numeric.spec.js
@@ -206,4 +206,10 @@ describe('vue-numeric.vue', () => {
     const wrapper = mount(component)
     expect(wrapper.data().total).to.equal(0)
   })
+
+  it('apply new separator immediately if it is changed', () => {
+    const wrapper = mount(VueNumeric, { propsData: { value: 2000, separator: "," } })
+    wrapper.setProps({ separator: "." })
+    expect(wrapper.data().amount).to.equal("2.000")
+  })
 })


### PR DESCRIPTION
If parent component changes seperator prop, the displayed value should change immediately and not after input interaction