### PR TITLE
Add watcher for currency prop

### DIFF
--- a/src/vue-numeric.vue
+++ b/src/vue-numeric.vue
@@ -270,6 +270,13 @@ export default {
     separator () {
       this.process(this.valueNumber)
       this.amount = this.format(this.valueNumber)
+    },
+    /**
+     * Immediately reflect currency changes
+     */
+    currency () {
+      this.process(this.valueNumber)
+      this.amount = this.format(this.valueNumber)
     }
   },
 

--- a/test/specs/vue-numeric.spec.js
+++ b/test/specs/vue-numeric.spec.js
@@ -212,4 +212,10 @@ describe('vue-numeric.vue', () => {
     wrapper.setProps({ separator: '.' })
     expect(wrapper.data().amount).to.equal('2.000')
   })
+
+  it('apply new currency prop immediately if it is changed', () => {
+    const wrapper = mount(VueNumeric, { propsData: { value: 0, currency: '$' } })
+    wrapper.setProps({ currency: 'USD' })
+    expect(wrapper.data().amount).to.equal('USD 0')
+  })
 })


### PR DESCRIPTION
Currency prop changes are now immediately reflected in the amount without having to focus the input element.