### PR TITLE
Fix excluding accounting-js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,9 +16,9 @@ module.exports = {
     extensions: ['.js', '.json', '.vue']
   },
   entry: './src/index.js',
-  externals: {
-    'accounting-js': 'accounting'
-  },
+  externals: [
+    'accounting-js'
+  ],
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: "vue-numeric.min.js",
@@ -46,4 +46,4 @@ module.exports = {
   performance: {
     hints: false
   }
-}
+};


### PR DESCRIPTION
Most recent version v2.2.0 has an issue with webpack build.

It excludes `accounting-js` but renames it to `accounting`.
When using in my project, webpack build failed saying you need to install `accounting` while `accounting-js` package was installed already.

This PR fixes this behaviour.

Expecting a new release soon.
Thanks.