### PR TITLE
fix: placeholder will prevent formating in mounted function

### DIFF
--- a/src/vue-numeric.vue
+++ b/src/vue-numeric.vue
@@ -131,7 +131,7 @@ export default {
      */
     value: {
       type: [Number, String],
-      default: 0,
+      default: '',
       required: true
     },
 

--- a/src/vue-numeric.vue
+++ b/src/vue-numeric.vue
@@ -267,7 +267,7 @@ export default {
 
   mounted () {
     // Set default value props when placeholder undefined.
-    if (!this.placeholder) {
+    if (!this.placeholder || this.value !== '') {
       this.process(this.valueNumber)
       this.amount = this.format(this.valueNumber)
 

--- a/test/specs/vue-numeric.spec.js
+++ b/test/specs/vue-numeric.spec.js
@@ -219,10 +219,16 @@ describe('vue-numeric.vue', () => {
     expect(process.called).to.equal(true)
   })
 
-  it('does not show default value when placeholder if defined', () => {
-    const wrapper = mount(VueNumeric, { propsData: { value: 2000, placeholder: 'number here' }})
+  it('does not show default value when placeholder if defined and input is empty', () => {
+    const wrapper = mount(VueNumeric, { propsData: { value: '', placeholder: 'number here' }})
     expect(wrapper.data().amount).to.equal('')
   })
+
+  it('ignore placeholder when input is not empty', () => {
+    const wrapper = mount(VueNumeric, { propsData: { value: 2000, placeholder: 'number here' }})
+    expect(wrapper.data().amount).to.equal('2,000')
+  })
+
 
   it('sets the value to 0 when no empty value is provided and input is empty', () => {
     const wrapper = mount(VueNumeric, { propsData: { value: '' }})


### PR DESCRIPTION
If someone just need show the placeholder when "value" is empty