### PR TITLE
Can now bind any listener provided by user to the input

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "karma-spec-reporter": "^0.0.31",
     "karma-webpack": "^2.0.4",
     "mocha": "^3.5.0",
+    "phantomjs-polyfill-object-assign": "0.0.2",
     "phantomjs-prebuilt": "^2.1.15",
     "sinon": "^3.2.1",
     "sinon-chai": "^2.13.0",

--- a/src/vue-numeric.vue
+++ b/src/vue-numeric.vue
@@ -1,13 +1,11 @@
 <template>
   <input
-    :placeholder="placeholder"
-    @blur="onBlurHandler"
-    @input="onInputHandler"
-    @focus="onFocusHandler"
-    ref="numeric"
-    type="tel"
-    v-model="amount"
     v-if="!readOnly"
+    ref="numeric"
+    v-model="amount"
+    :placeholder="placeholder"
+    type="tel"
+    v-on="inputListeners"
   >
   <span
     v-else
@@ -193,6 +191,21 @@ export default {
       if (typeof this.decimalSeparator !== 'undefined') return this.decimalSeparator
       if (this.separator === ',') return '.'
       return ','
+    },
+
+    /**
+     * Define listeners to attach to the input
+     */
+    inputListeners () {
+      var vm = this;
+      return Object.assign({},
+        this.$listeners,
+        {
+          blur: vm.onBlurHandler,
+          input: vm.onInputHandler,
+          focus: vm.onFocusHandler,
+        }
+      );
     },
 
     /**

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -7,7 +7,10 @@ module.exports = config => {
     browsers: ['PhantomJS'],
     frameworks: ['mocha', 'sinon-chai'],
     reporters: ['spec', 'coverage'],
-    files: ['specs/*.spec.js'],
+    files: [
+      '../node_modules/phantomjs-polyfill-object-assign/object-assign-polyfill.js',
+      'specs/*.spec.js'
+    ],
     preprocessors: {
       './specs/*.spec.js': ['webpack', 'sourcemap']
     },


### PR DESCRIPTION
This PR allows developers to bind any listener they like to the input element, rather than just specific ones. This is really useful for things like preventing the enter key submitting the form for instance, and I'm sure many other use cases.