### PR TITLE
Added `disabled` prop to render a disabled input rather than a span

### DIFF
--- a/src/vue-numeric.vue
+++ b/src/vue-numeric.vue
@@ -8,7 +8,7 @@
     type="tel"
     v-model="amount"
     v-if="!readOnly"
-    :disabled='disabled'
+    :disabled="disabled"
   >
   <span
     v-else

--- a/src/vue-numeric.vue
+++ b/src/vue-numeric.vue
@@ -8,6 +8,7 @@
     type="tel"
     v-model="amount"
     v-if="!readOnly"
+    :disabled='disabled'
   >
   <span
     v-else
@@ -153,6 +154,12 @@ export default {
       required: false
     },
 
+    disabled: {
+      type: Boolean,
+      default: false,
+      required: false,
+    },
+
     /**
      * Position of currency symbol
      * Symbol position props accept either 'suffix' or 'prefix' (default).
@@ -161,7 +168,7 @@ export default {
       type: String,
       default: 'prefix',
       required: false
-    }
+    },
   },
 
   data: () => ({

--- a/test/specs/vue-numeric.spec.js
+++ b/test/specs/vue-numeric.spec.js
@@ -109,6 +109,28 @@ describe('vue-numeric.vue', () => {
     })
   })
 
+  it('is is not disabled when disabled mode is disabled', done => {
+    const propsData = { value: 3000, disabled: true }
+    const wrapper = mount(VueNumeric, { propsData })
+
+    wrapper.setProps({ disabled: false })
+    wrapper.instance().$nextTick(() => {
+      expect(wrapper.instance().$el.hasAttribute('disabled')).to.equal(false)
+      done()
+    })
+  })
+
+  it('is disabled in disabled mode', done => {
+    const propsData = { value: 3000, disabled: false }
+    const wrapper = mount(VueNumeric, { propsData })
+
+    wrapper.setProps({ disabled: true })
+    wrapper.instance().$nextTick(() => {
+      expect(wrapper.instance().$el.hasAttribute('disabled')).to.equal(true)
+      done()
+    })
+  });
+
   it('cannot exceed max props', () => {
     const component = Vue.extend({
       data: () => ({ total: 150 }),


### PR DESCRIPTION
This PR allows the number input to be disabled. Similar to the `readOnly` prop, but instead of changing the output to a span with the value, it remains an input but simply marks it as disabled.