### PR TITLE
Add check for a ZERO value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-numeric",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Input field component to display currency value based on Vue.",
   "author": "Kevin Ongko",
   "main": "dist/vue-numeric.min.js",

--- a/src/vue-numeric.vue
+++ b/src/vue-numeric.vue
@@ -275,7 +275,7 @@ export default {
 
   mounted () {
     // Set default value props when valueNumber has some value
-    if (this.valueNumber) {
+    if (this.valueNumber || this.isDeliberatelyZero()) {
       this.process(this.valueNumber)
       this.amount = this.format(this.valueNumber)
 
@@ -377,6 +377,14 @@ export default {
     unformat (value) {
       const toUnformat = typeof value === 'string' && value === '' ? this.emptyValue : value
       return accounting.unformat(toUnformat, this.decimalSeparatorSymbol)
+    },
+
+    /**
+     * Check if value was deliberately set to zero and not just evaluated
+     * @return {boolean}
+     */
+    isDeliberatelyZero () {
+      return this.valueNumber === 0 && this.value !== '';
     }
   }
 }

--- a/test/specs/vue-numeric.spec.js
+++ b/test/specs/vue-numeric.spec.js
@@ -313,4 +313,8 @@ describe('vue-numeric.vue', () => {
     wrapper.trigger('change')
     expect(process.called).to.equal(true)
   })
+  it('initial value is 0 if zero is passed', () => {
+    const wrapper = mount(VueNumeric, { propsData: { value: 0}})
+    expect(wrapper.data().amount).to.equal('0')
+  })
 })


### PR DESCRIPTION
The JS language considers the value ZERO to be
"false". This has to do with the fact that the
numeric representation of true/false are 1/0.

This was of course preventing the initial value
of a numeric field to be set to zero since there
was a check on the mounted function that saw if
the value was defined.

I've added a simple OR case, where if the value
was evaluated to FALSE than we check again for
if the value is zero. This fixed the case where
the value ZERO was not being shown when it was
deliberately chosen.

It did break another case when we pass an empty
string. To fix it I also test if the original value
is not empty (which would be evaluated to zero)

> Make sure to read the [contribution guidelines](https://github.com/kevinongko/vue-numeric/blob/master/.github/CONTRIBUTING.md) before submitting PR.